### PR TITLE
Update influxDB version 2.7

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ${{ matrix.config.os }}
     strategy:
       matrix:
-        python-version: [3.6]
+        python-version: [3.9]
         config:
           - os: ubuntu-latest
           - os: macos-latest

--- a/recipe.yaml
+++ b/recipe.yaml
@@ -107,6 +107,6 @@ Manifests:
           echo "Removing the InfluxDB container..."
           docker rm {configuration:/InfluxDBContainerName}
     Artifacts:
-      - URI: 'docker:influxdb:2.0.9' 
+      - URI: 'docker:influxdb:2.7' 
       - URI: s3://aws-greengrass-labs-database-influxdb.zip
         Unarchive: ZIP

--- a/src/influxdb_utils.sh
+++ b/src/influxdb_utils.sh
@@ -130,7 +130,7 @@ setup_blank_influxdb_with_http() {
     --read-only \
     -v "$INFLUXDB_MOUNT_PATH"/influxdb2/data:/var/lib/influxdb2 \
     -v "$INFLUXDB_MOUNT_PATH"/influxdb2/config:/etc/influxdb2 \
-    influxdb:2.0.9
+    influxdb:2.7
 }
 
 provision_influxdb(){
@@ -174,7 +174,7 @@ provision_influxdb(){
       -v "$INFLUXDB_MOUNT_PATH"/influxdb2_certs/:/etc/ssl/greengrass:ro \
       -e INFLUXD_TLS_CERT=/etc/ssl/greengrass/influxdb.crt \
       -e INFLUXD_TLS_KEY=/etc/ssl/greengrass/influxdb.key \
-      influxdb:2.0.9
+      influxdb:2.7
 
       wait_for_influxdb_start "$CONTAINER_NAME" "$INFLUXDB_PORT" "$SERVER_PROTOCOL" "$SKIP_TLS_VERIFY"
   else


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
As part of a blog we're working on replicating data from InfluxDB on the Edge device to AWS Timestream(InfluxDB) on Cloud.
This was possible by updating the influxdb image from `2.0.9` to `2.7`
**Why is this change necessary:**

**How was this change tested:**
On my AWS Account

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [ ] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [x ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.